### PR TITLE
Comments Manifest entry on `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,4 +21,4 @@ docs/site/
 # It records a fixed state of all packages used by the project. As such, it should not be
 # committed for packages, but should be committed for applications that require a static
 # environment.
-Manifest.toml
+# Manifest.toml


### PR DESCRIPTION
I think we want to keep track of Manifest.jl so that our codes are reproducible across devices.