### PR TITLE
Update Kelvin-helmholtz example

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -287,10 +287,10 @@ uuid = "61eb1bfa-7361-4325-ad38-22787b887f55"
 version = "0.12.9"
 
 [[GR]]
-deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "30f2b340c2fff8410d89bfcdc9c0a6dd661ac5f7"
+deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "4a740db447aae0fbeb3ee730de1afbb14ac798a1"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.62.1"
+version = "0.63.1"
 
 [[GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
@@ -406,9 +406,9 @@ version = "1.0.0"
 
 [[JLD2]]
 deps = ["DataStructures", "FileIO", "MacroTools", "Mmap", "Pkg", "Printf", "Reexport", "TranscodingStreams", "UUIDs"]
-git-tree-sha1 = "46b7834ec8165c541b0b5d1c8ba63ec940723ffb"
+git-tree-sha1 = "bcb31db46795eeb64480c89d854615bc78a13289"
 uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
-version = "0.4.15"
+version = "0.4.19"
 
 [[JLLWrappers]]
 deps = ["Preferences"]
@@ -646,6 +646,14 @@ git-tree-sha1 = "3f0b34f3907f1b8a7d564f71ddc6f7d248c7c346"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
 version = "0.69.2"
 
+[[Oceanostics]]
+deps = ["Oceananigans", "Printf"]
+git-tree-sha1 = "5313597f97ac4c37e0ed8a5c8518240afc140ba6"
+repo-rev = "main"
+repo-url = "https://github.com/tomchor/Oceanostics.jl.git"
+uuid = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
+version = "0.6.3"
+
 [[OffsetArrays]]
 deps = ["Adapt"]
 git-tree-sha1 = "043017e0bdeff61cfbb7afeb558ab29536bbb5ed"
@@ -738,10 +746,10 @@ uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
 version = "1.1.3"
 
 [[Plots]]
-deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun"]
-git-tree-sha1 = "8789439a899b77f4fbb4d7298500a6a5781205bc"
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
+git-tree-sha1 = "7e4920a7d4323b8ffc3db184580598450bde8a8e"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.25.0"
+version = "1.25.7"
 
 [[Preferences]]
 deps = ["TOML"]
@@ -792,14 +800,20 @@ version = "1.2.1"
 
 [[RecipesPipeline]]
 deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
-git-tree-sha1 = "7ad0dfa8d03b7bcf8c597f59f5292801730c55b8"
+git-tree-sha1 = "37c1631cb3cc36a535105e6d5557864c82cd8c2b"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.4.1"
+version = "0.5.0"
 
 [[Reexport]]
 git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
 version = "1.2.2"
+
+[[RelocatableFolders]]
+deps = ["SHA", "Scratch"]
+git-tree-sha1 = "cdbd3b1338c72ce29d9584fdbe9e9b70eeb5adca"
+uuid = "05181044-ff0b-4ac5-8273-598c1e38db00"
+version = "0.1.3"
 
 [[Requires]]
 deps = ["UUIDs"]
@@ -985,6 +999,11 @@ deps = ["REPL"]
 git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
 uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
 version = "0.4.1"
+
+[[Unzip]]
+git-tree-sha1 = "34db80951901073501137bdbc3d5a8e7bbd06670"
+uuid = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
+version = "0.1.2"
 
 [[Wayland_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]

--- a/Manifest.toml
+++ b/Manifest.toml
@@ -17,9 +17,9 @@ uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
 
 [[ArrayInterface]]
 deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
-git-tree-sha1 = "ffc6588e17bcfcaa79dfa5b4f417025e755f83fc"
+git-tree-sha1 = "1bdcc02836402d104a46f7843b6e6730b1948264"
 uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
-version = "4.0.1"
+version = "4.0.2"
 
 [[Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -270,9 +270,9 @@ version = "1.0.10+0"
 
 [[GLFW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pkg", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll"]
-git-tree-sha1 = "0c603255764a1fa0b61752d2bec14cfbd18f7fe8"
+git-tree-sha1 = "51d2dfe8e590fbd74e7a842cf6d13d8a2f45dc01"
 uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
-version = "3.3.5+1"
+version = "3.3.6+0"
 
 [[GPUArrays]]
 deps = ["Adapt", "LLVM", "LinearAlgebra", "Printf", "Random", "Serialization", "Statistics"]
@@ -334,9 +334,9 @@ version = "1.0.2"
 
 [[HDF5_jll]]
 deps = ["Artifacts", "JLLWrappers", "LibCURL_jll", "Libdl", "OpenSSL_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "bab67c0d1c4662d2c4be8c6007751b0b6111de5c"
+git-tree-sha1 = "fd83fa0bde42e01952757f01149dd968c06c4dba"
 uuid = "0234f1f7-429e-5d53-9886-15a909be8d59"
-version = "1.12.1+0"
+version = "1.12.0+1"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
@@ -412,9 +412,9 @@ version = "0.4.19"
 
 [[JLLWrappers]]
 deps = ["Preferences"]
-git-tree-sha1 = "22df5b96feef82434b07327e2d3c770a9b21e023"
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.4.0"
+version = "1.4.1"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
@@ -633,18 +633,18 @@ version = "0.3.7"
 
 [[NetCDF_jll]]
 deps = ["Artifacts", "HDF5_jll", "JLLWrappers", "LibCURL_jll", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Pkg", "Zlib_jll", "nghttp2_jll"]
-git-tree-sha1 = "03af9979e5f60b7ac42a428a5beb5282ffec45ca"
+git-tree-sha1 = "0cf4d1bf2ef45156aed85c9ac5f8c7e697d9288c"
 uuid = "7243133f-43d8-5620-bbf4-c2c921802cf3"
-version = "400.802.101+0"
+version = "400.702.400+0"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[Oceananigans]]
 deps = ["Adapt", "CUDA", "CUDAKernels", "Crayons", "CubedSphere", "Dates", "DocStringExtensions", "FFTW", "Glob", "IncompleteLU", "InteractiveUtils", "IterativeSolvers", "JLD2", "KernelAbstractions", "LinearAlgebra", "Logging", "MPI", "NCDatasets", "OffsetArrays", "OrderedCollections", "PencilFFTs", "Pkg", "Printf", "Random", "Rotations", "SafeTestsets", "SeawaterPolynomials", "SparseArrays", "Statistics", "StructArrays", "Tullio"]
-git-tree-sha1 = "3f0b34f3907f1b8a7d564f71ddc6f7d248c7c346"
+git-tree-sha1 = "7f5d4ad75a4c791f0aa702c8002c345061b513d3"
 uuid = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
-version = "0.69.2"
+version = "0.69.3"
 
 [[Oceanostics]]
 deps = ["Oceananigans", "Printf"]
@@ -887,9 +887,9 @@ version = "0.5.1"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "2884859916598f974858ff01df7dfc6c708dd895"
+git-tree-sha1 = "a635a9333989a094bddc9f940c04c549cd66afcf"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.3.3"
+version = "1.3.4"
 
 [[StaticPermutations]]
 git-tree-sha1 = "193c3daa18ff3e55c1dae66acb6a762c4a3bdb0b"

--- a/Project.toml
+++ b/Project.toml
@@ -1,4 +1,5 @@
 [deps]
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 Oceananigans = "9e8cae18-63c1-5223-a75c-80ca9d6e9a09"
+Oceanostics = "d0ccf422-c8fb-49b5-a76d-74acdde946ac"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"

--- a/kelvin_helmholtz.jl
+++ b/kelvin_helmholtz.jl
@@ -3,26 +3,14 @@ using Oceananigans.Units
 using Printf
 
 L = 10
-grid = RectilinearGrid(size=(32, 32, 64), x=(-L/2, L/2), y=(-L/2, L/2), z=(-L/2, L/2),
+grid = RectilinearGrid(size=(64, 64, 128), x=(-L/2, L/2), y=(-L/2, L/2), z=(-L/2, L/2),
                        topology=(Periodic, Periodic, Bounded))
 
-shear_flow(x, y, z, t) = tanh(z)
-
-stratification(x, y, z, t, p) = p.h * p.Ri * tanh(z / p.h)
-
-U = BackgroundField(shear_flow)
-
-B = BackgroundField(stratification, parameters=(Ri=0.1, h=1/4))
 
 # Our basic state thus has a thin layer of stratification in the center of
 # the channel, embedded within a thicker shear layer surrounded by unstratified fluid.
 
-using Plots
-
-zF = znodes(Face, grid)
-zC = znodes(Center, grid)
-
-Ri, h = B.parameters
+Ri, h = 0.1, 1/4
 
 IsotropicDiffusivity(ν=2e-4, κ=2e-4)
 closure = SmagorinskyLilly(C=16)
@@ -30,18 +18,23 @@ model = NonhydrostaticModel(timestepper = :RungeKutta3,
                               advection = UpwindBiasedFifthOrder(),
                                    grid = grid,
                                coriolis = nothing,
-                      background_fields = (u=U, b=B),
                                 closure = closure,
                                buoyancy = BuoyancyTracer(),
                                 tracers = :b)
 
 amplitude = 1e-4
 noise(x, y, z) = amplitude * randn()
-set!(model, u=noise, v=noise, w=noise)
+
+shear_flow(x, y, z) = tanh(z) + noise(x, y, z)
+stratification(x, y, z) = h * Ri * tanh(z / h) + noise(x, y, z)
+set!(model, u=shear_flow, v=noise, w=noise, b=stratification)
 
 stop_time = 200
-simulation = Simulation(model, Δt=0.0001 * grid.Δzᵃᵃᶜ / maximum(model.velocities.u),
+Δt_diffusive = grid.Δzᵃᵃᶜ^2 / maximum(model.diffusivity_fields.νₑ)
+Δt_advective = grid.Δzᵃᵃᶜ / maximum(model.velocities.u)
+simulation = Simulation(model, Δt=0.5 * min(Δt_advective, Δt_diffusive),
                         stop_time=stop_time)
+
 
 # Simple logging
 using Oceanostics: SingleLineProgressMessenger
@@ -49,18 +42,16 @@ progress = SingleLineProgressMessenger(LES=true)
 simulation.callbacks[:progress] = Callback(progress, IterationInterval(1))
 
 # Adaptive time-stepping
-wizard = TimeStepWizard(cfl=0.8, diffusive_cfl=0.1, max_change=1.02, min_change=0.1)
+wizard = TimeStepWizard(cfl=0.8, diffusive_cfl=0.5, max_change=1.02, min_change=0.1)
 simulation.callbacks[:wizard] = Callback(wizard, IterationInterval(1))
 
 u, v, w = model.velocities
 b = model.tracers.b
 
-total_vorticity = Field(∂z(u) + ∂z(model.background_fields.velocities.u) - ∂x(w))
-
-total_b = Field(b + model.background_fields.tracers.b)
+total_vorticity = Field(∂z(u) - ∂x(w))
 
 simulation.output_writers[:snapshots] =
-    JLD2OutputWriter(model, (Ω=total_vorticity, b=b, B=total_b, νₑ=model.diffusivity_fields.νₑ),
+    JLD2OutputWriter(model, (Ω=total_vorticity, b=b, νₑ=model.diffusivity_fields.νₑ),
                      schedule = TimeInterval(1),
                      field_slicer = FieldSlicer(j=1),
                      prefix = "kelvin_helmholtz_instability",
@@ -72,7 +63,7 @@ run!(simulation)
 
 
 # Now we plot stuff
-
+using Plots
 using Printf
 using JLD2
 
@@ -116,7 +107,7 @@ anim_total = @animate for (i, iteration) in enumerate(iterations)
 
     t = file["timeseries/t/$iteration"]
     ω_snapshot = file["timeseries/Ω/$iteration"][:, 1, :]
-    b_snapshot = file["timeseries/B/$iteration"][:, 1, :]
+    b_snapshot = file["timeseries/b/$iteration"][:, 1, :]
 
     eigenmode_plot = eigenplot(ω_snapshot, b_snapshot, nothing, t; ω_lim=1, b_lim=0.05)
 


### PR DESCRIPTION
I created this PR based on https://github.com/tomchor/AGUOSM22-LES-tutorial/pull/4 as a working area for solving a weird behavior associated with it. I didn't want to "pollute" that PR with this issue, but also wanted a place to store progress. _Note that this PR merges into `tc/kh-dynamics`, not `main`._

Also @glwagner I thought things here might be relevant to our discussion in https://github.com/CliMA/Oceananigans.jl/pull/2205

Here's the explanation:

Here I'm updating the code to use an LES closure and I'm setting `diffusive_cfl=0.1`. Since the simulation in so coarse (done on purpose for now) the diffusivity is actually pretty high, and `diffusive_cfl` is the limiting factor. However, the `TimeStepWizard` doesn't seem to control for that parameter (meaning the `diffusive_cfl` does go over 0.1 apparently without `TimeStepWizard` trying to reduce it).

Here's an output for that simulation illustrating that despite `diffusive_cfl=0.1), the time step keeps increasing past that mark:

```julia
[ Info: [008.94%] iter:    114,     time: 17.872 seconds,     Δt: 440.416 ms,     wall time: 430.999 ns,     adv CFL: 3.71e-04,     diff CFL: 1.69e-01,     νₘₐₓ: 9.38e-03 m²/s
[ Info: [009.00%] iter:    115,     time: 18 seconds,     Δt: 449.224 ms,     wall time: 430.999 ns,     adv CFL: 3.76e-04,     diff CFL: 1.76e-01,     νₘₐₓ: 9.55e-03 m²/s
[ Info: [009.23%] iter:    116,     time: 18.458 seconds,     Δt: 458.209 ms,     wall time: 280.997 ns,     adv CFL: 3.90e-04,     diff CFL: 1.82e-01,     νₘₐₓ: 9.67e-03 m²/s
[ Info: [009.46%] iter:    117,     time: 18.926 seconds,     Δt: 467.373 ms,     wall time: 471.002 ns,     adv CFL: 4.03e-04,     diff CFL: 1.71e-01,     νₘₐₓ: 8.94e-03 m²/s
[ Info: [009.50%] iter:    118,     time: 19 seconds,     Δt: 476.720 ms,     wall time: 681.997 ns,     adv CFL: 4.11e-04,     diff CFL: 1.77e-01,     νₘₐₓ: 9.05e-03 m²/s
[ Info: [009.74%] iter:    119,     time: 19.486 seconds,     Δt: 486.255 ms,     wall time: 431.006 ns,     adv CFL: 4.23e-04,     diff CFL: 1.94e-01,     νₘₐₓ: 9.73e-03 m²/s
[ Info: [009.99%] iter:    120,     time: 19.982 seconds,     Δt: 495.980 ms,     wall time: 530.999 ns,     adv CFL: 4.34e-04,     diff CFL: 1.85e-01,     νₘₐₓ: 9.09e-03 m²/s
[ Info: [010.00%] iter:    121,     time: 20 seconds,     Δt: 505.899 ms,     wall time: 291.002 ns,     adv CFL: 4.43e-04,     diff CFL: 1.89e-01,     νₘₐₓ: 9.13e-03 m²/s
[ Info: [010.26%] iter:    122,     time: 20.516 seconds,     Δt: 516.017 ms,     wall time: 530.999 ns,     adv CFL: 4.52e-04,     diff CFL: 2.17e-01,     νₘₐₓ: 1.03e-02 m²/s
[ Info: [010.50%] iter:    123,     time: 21 seconds,     Δt: 526.338 ms,     wall time: 1.152 μs,     adv CFL: 4.68e-04,     diff CFL: 2.28e-01,     νₘₐₓ: 1.06e-02 m²/s
[ Info: [010.77%] iter:    124,     time: 21.537 seconds,     Δt: 536.864 ms,     wall time: 772.001 ns,     adv CFL: 4.79e-04,     diff CFL: 2.26e-01,     νₘₐₓ: 1.03e-02 m²/s
[ Info: [011.00%] iter:    125,     time: 22 seconds,     Δt: 547.602 ms,     wall time: 431.006 ns,     adv CFL: 4.88e-04,     diff CFL: 2.27e-01,     νₘₐₓ: 1.01e-02 m²/s
[ Info: [011.28%] iter:    126,     time: 22.559 seconds,     Δt: 558.554 ms,     wall time: 651.002 ns,     adv CFL: 4.91e-04,     diff CFL: 2.60e-01,     νₘₐₓ: 1.13e-02 m²/s
[ Info: [011.50%] iter:    127,     time: 23.000 seconds,     Δt: 569.725 ms,     wall time: 620.996 ns,     adv CFL: 5.06e-04,     diff CFL: 3.00e-01,     νₘₐₓ: 1.28e-02 m²/s
[ Info: [011.50%] iter:    128,     time: 23 seconds,     Δt: 581.119 ms,     wall time: 401.000 ns,     adv CFL: 5.17e-04,     diff CFL: 3.06e-01,     νₘₐₓ: 1.28e-02 m²/s
[ Info: [011.80%] iter:    129,     time: 23.593 seconds,     Δt: 592.742 ms,     wall time: 421.001 ns,     adv CFL: 5.15e-04,     diff CFL: 3.19e-01,     νₘₐₓ: 1.32e-02 m²/s
[ Info: [012.00%] iter:    130,     time: 24 seconds,     Δt: 604.597 ms,     wall time: 411.004 ns,     adv CFL: 5.16e-04,     diff CFL: 3.31e-01,     νₘₐₓ: 1.34e-02 m²/s
[ Info: [012.31%] iter:    131,     time: 24.617 seconds,     Δt: 616.689 ms,     wall time: 411.004 ns,     adv CFL: 5.20e-04,     diff CFL: 3.53e-01,     νₘₐₓ: 1.40e-02 m²/s
[ Info: [012.50%] iter:    132,     time: 25 seconds,     Δt: 629.022 ms,     wall time: 560.998 ns,     adv CFL: 5.06e-04,     diff CFL: 3.29e-01,     νₘₐₓ: 1.28e-02 m²/s
[ Info: [012.82%] iter:    133,     time: 25.642 seconds,     Δt: 641.603 ms,     wall time: 1.633 μs,     adv CFL: 5.04e-04,     diff CFL: 4.17e-01,     νₘₐₓ: 1.59e-02 m²/s
[ Info: [013.00%] iter:    134,     time: 26 seconds,     Δt: 654.435 ms,     wall time: 401.000 ns,     adv CFL: 4.90e-04,     diff CFL: 4.53e-01,     νₘₐₓ: 1.69e-02 m²/s
[ Info: [013.33%] iter:    135,     time: 26.668 seconds,     Δt: 667.523 ms,     wall time: 421.001 ns,     adv CFL: 4.89e-04,     diff CFL: 3.94e-01,     νₘₐₓ: 1.44e-02 m²/s
[ Info: [013.50%] iter:    136,     time: 27 seconds,     Δt: 680.874 ms,     wall time: 270.004 ns,     adv CFL: 4.97e-04,     diff CFL: 3.63e-01,     νₘₐₓ: 1.30e-02 m²/s
[ Info: [013.85%] iter:    137,     time: 27.694 seconds,     Δt: 694.491 ms,     wall time: 371.001 ns,     adv CFL: 4.93e-04,     diff CFL: 4.13e-01,     νₘₐₓ: 1.45e-02 m²/s
[ Info: [014.00%] iter:    138,     time: 28 seconds,     Δt: 708.381 ms,     wall time: 430.999 ns,     adv CFL: 4.92e-04,     diff CFL: 4.14e-01,     νₘₐₓ: 1.43e-02 m²/s
[ Info: [014.36%] iter:    139,     time: 28.723 seconds,     Δt: 722.549 ms,     wall time: 391.003 ns,     adv CFL: 5.02e-04,     diff CFL: 3.65e-01,     νₘₐₓ: 1.23e-02 m²/s
[ Info: [014.50%] iter:    140,     time: 29 seconds,     Δt: 737.000 ms,     wall time: 389.999 ns,     adv CFL: 5.11e-04,     diff CFL: 3.42e-01,     νₘₐₓ: 1.13e-02 m²/s
[ Info: [014.88%] iter:    141,     time: 29.752 seconds,     Δt: 751.740 ms,     wall time: 471.002 ns,     adv CFL: 1.90e-03,     diff CFL: 1.47e+00,     νₘₐₓ: 4.76e-02 m²/s
[ Info: [015.00%] iter:    142,     time: 30 seconds,     Δt: 766.775 ms,     wall time: 421.001 ns,     adv CFL: 1.16e-03,     diff CFL: 9.45e-01,     νₘₐₓ: 3.01e-02 m²/s
[ Info: [015.39%] iter:    143,     time: 30.782 seconds,     Δt: 782.110 ms,     wall time: 401.000 ns,     adv CFL: 1.04e-02,     diff CFL: 2.44e+01,     νₘₐₓ: 7.61e-01 m²/s
[ Info: [015.50%] iter:    144,     time: 31 seconds,     Δt: 797.752 ms,     wall time: 301.006 ns,     adv CFL: 1.44e+05,     diff CFL: 3.28e+08,     νₘₐₓ: 1.00e+07 m²/s
[ Info: [015.54%] iter:    145,     time: 31.080 seconds,     Δt:  79.775 ms,     wall time: 300.999 ns,     adv CFL: 4.01e+58,     diff CFL: 8.82e+61,     νₘₐₓ: 2.70e+61 m²/s
[ Info: [015.54%] iter:    146,     time: 31.088 seconds,     Δt:   7.978 ms,     wall time: 581.000 ns,     adv CFL: NaN,     diff CFL: NaN,     νₘₐₓ: NaN m²/s
```

I don't really understand why. I might be forgetting something and I'm gonna investigate this behavior more in depth later.